### PR TITLE
Поправил команду установки Pillow

### DIFF
--- a/vgg16.ipynb
+++ b/vgg16.ipynb
@@ -112,7 +112,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install pillow"
+    "!pip install -U pillow"
    ]
   },
   {


### PR DESCRIPTION
Во флажок написали, что у некоторых не принимался ответ во втором задании из-за того, что на вход сети подавались изображения jpg загруженные через несвежую библиотеку Pillow.

Поэтому в ноутбуке в команду установки Pillow был добавлен флаг обновления библиотеки.